### PR TITLE
Lockon Info

### DIFF
--- a/Data/Scripts/CoreSystems/Session/SessionUpdate.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionUpdate.cs
@@ -283,7 +283,7 @@ namespace CoreSystems
                         ///
                         /// Update Weapon Hud Info
                         /// 
-                        var addWeaponToHud = HandlesInput && (w.HeatPerc >= 0.01 || w.Loading && w.ShowReload);
+                        var addWeaponToHud = HandlesInput && (w.HeatPerc >= 0.01 || w.Loading && w.ShowReload || w.System.LockOnFocus);
                         if (addWeaponToHud && !Session.Config.MinimalHud && ActiveControlBlock != null && ai.SubGrids.Contains(ActiveControlBlock.CubeGrid)) {
                             HudUi.TexturesToAdd++;
                             HudUi.WeaponsToDisplay.Add(w);

--- a/Data/Scripts/CoreSystems/Ui/Hud/HudDraw.cs
+++ b/Data/Scripts/CoreSystems/Ui/Hud/HudDraw.cs
@@ -229,7 +229,7 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui.Hud
                 TextDrawRequest textInfo;
                 var stackedInfo = _weapontoDraw[i];
                 var weapon = stackedInfo.HighestValueWeapon;
-				var needsLock = weapon.System.LockOnFocus ? "Lockon to fire" : "";
+				var needsLock = weapon.System.LockOnFocus ? "Lock to fire" : "";
                 var name = weapon.System.PartName + ": " + needsLock;
 
                 var textOffset = bgStartPosX - _bgWidth + _reloadWidth + _padding;

--- a/Data/Scripts/CoreSystems/Ui/Hud/HudDraw.cs
+++ b/Data/Scripts/CoreSystems/Ui/Hud/HudDraw.cs
@@ -229,9 +229,11 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui.Hud
                 TextDrawRequest textInfo;
                 var stackedInfo = _weapontoDraw[i];
                 var weapon = stackedInfo.HighestValueWeapon;
+                
+                
                 var currLock = _session.TrackingAi.Construct.Data.Repo.FocusData.Locked[0].ToString();
-                var needsLock = weapon.System.LockOnFocus && currLock == "None" ? "Lock to fire" : "";
-                var name = weapon.System.PartName + ": " + needsLock;
+                var needsLock = weapon.System.LockOnFocus && currLock == "None" ? "Need Lock" : "Locked On";
+                var name = weapon.System.PartName + ": " + (weapon.System.LockOnFocus ? needsLock : "");
 
                 var textOffset = bgStartPosX - _bgWidth + _reloadWidth + _padding;
                 var hasHeat = weapon.HeatPerc > 0;

--- a/Data/Scripts/CoreSystems/Ui/Hud/HudDraw.cs
+++ b/Data/Scripts/CoreSystems/Ui/Hud/HudDraw.cs
@@ -229,7 +229,8 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui.Hud
                 TextDrawRequest textInfo;
                 var stackedInfo = _weapontoDraw[i];
                 var weapon = stackedInfo.HighestValueWeapon;
-                var name = weapon.System.PartName + ": ";
+				var needsLock = weapon.System.LockOnFocus ? "Lockon to fire" : "";
+                var name = weapon.System.PartName + ": " + needsLock;
 
                 var textOffset = bgStartPosX - _bgWidth + _reloadWidth + _padding;
                 var hasHeat = weapon.HeatPerc > 0;

--- a/Data/Scripts/CoreSystems/Ui/Hud/HudDraw.cs
+++ b/Data/Scripts/CoreSystems/Ui/Hud/HudDraw.cs
@@ -229,7 +229,8 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui.Hud
                 TextDrawRequest textInfo;
                 var stackedInfo = _weapontoDraw[i];
                 var weapon = stackedInfo.HighestValueWeapon;
-				var needsLock = weapon.System.LockOnFocus ? "Lock to fire" : "";
+                var currLock = _session.TrackingAi.Construct.Data.Repo.FocusData.Locked[0].ToString();
+                var needsLock = weapon.System.LockOnFocus && currLock == "None" ? "Lock to fire" : "";
                 var name = weapon.System.PartName + ": " + needsLock;
 
                 var textOffset = bgStartPosX - _bgWidth + _reloadWidth + _padding;

--- a/Data/Scripts/CoreSystems/Ui/Hud/HudFields.cs
+++ b/Data/Scripts/CoreSystems/Ui/Hud/HudFields.cs
@@ -27,7 +27,7 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui.Hud
         private const float ShadowHeightScaler = 0.65f;
         private const float ShadowSizeScaler = 1.5f;
         private const int WeaponLimit = 50;
-        private const int StackThreshold = 1;
+        private const int StackThreshold = 10;
 
         private const int InitialPoolCapacity = 512;
         private const uint MinUpdateTicks = 60;

--- a/Data/Scripts/CoreSystems/Ui/Hud/HudFields.cs
+++ b/Data/Scripts/CoreSystems/Ui/Hud/HudFields.cs
@@ -27,7 +27,7 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui.Hud
         private const float ShadowHeightScaler = 0.65f;
         private const float ShadowSizeScaler = 1.5f;
         private const int WeaponLimit = 50;
-        private const int StackThreshold = 10;
+        private const int StackThreshold = 1;
 
         private const int InitialPoolCapacity = 512;
         private const uint MinUpdateTicks = 60;

--- a/Data/Scripts/CoreSystems/Ui/Hud/HudSupport.cs
+++ b/Data/Scripts/CoreSystems/Ui/Hud/HudSupport.cs
@@ -113,7 +113,7 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui.Hud
 
             if (list.Count > WeaponLimit) //limit to top 50 based on heat
                 list.RemoveRange(WeaponLimit, list.Count - WeaponLimit);
-            else if (list.Count <= StackThreshold)
+            else if (list.Count <= 1)
             {
                 for (int i = 0; i < list.Count; i++)
                 {


### PR DESCRIPTION
Lockon text added for weapons that need it "Need Lock" or "Locked On" will display.  Groups of weapons set to automatically collapse, but will still break out if conditions vary, such as heat or reload status.