### PR TITLE
Fixed?  Fixed.

### DIFF
--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
@@ -196,6 +196,8 @@ namespace CoreSystems.Support
         public readonly float AreaAffectMaxDepth;//bdc addin
         public readonly float DetonationMaxDepth;//bdc addin
         public readonly float AreaEffectMaxAbsorb;//bdc addin
+        public readonly float DetonationMaxAbsorb;//bdc addin
+
 
         public readonly float AreaEffectDamage;
         public readonly float DetonationDamage;
@@ -319,9 +321,9 @@ namespace CoreSystems.Support
             MaxLateralThrust = MathHelperD.Clamp(ammo.AmmoDef.Trajectory.Smarts.MaxLateralThrust, 0.000001, 1);
 
             Fields(ammo.AmmoDef, out PulseInterval, out PulseChance, out Pulse, out PulseGrowTime);
-            
+
             //BDC addin max depths & max absorb
-            AreaEffects(ammo.AmmoDef, out AreaEffectMaxAbsorb, out AreaAffectMaxDepth, out DetonationMaxDepth, out AreaEffect, out AreaEffectDamage, out AreaEffectSize, out DetonationDamage, out DetonationRadius, out AmmoAreaEffect, out AreaRadiusSmall, out AreaRadiusLarge, out DetonateRadiusSmall, out DetonateRadiusLarge, out Ewar, out EwarEffect, out EwarTriggerRange, out MinArmingTime); ;
+            AreaEffects(ammo.AmmoDef, out DetonationMaxAbsorb, out AreaEffectMaxAbsorb, out AreaAffectMaxDepth, out DetonationMaxDepth, out AreaEffect, out AreaEffectDamage, out AreaEffectSize, out DetonationDamage, out DetonationRadius, out AmmoAreaEffect, out AreaRadiusSmall, out AreaRadiusLarge, out DetonateRadiusSmall, out DetonateRadiusLarge, out Ewar, out EwarEffect, out EwarTriggerRange, out MinArmingTime); ; ;
             Beams(ammo.AmmoDef, out IsBeamWeapon, out VirtualBeams, out RotateRealBeam, out ConvergeBeams, out OneHitParticle, out OffsetEffect);
 
             var givenSpeed = AmmoModsFound && _modifierMap[SpeedStr].HasData() ? _modifierMap[SpeedStr].GetAsFloat : ammo.AmmoDef.Trajectory.DesiredSpeed;
@@ -713,7 +715,7 @@ namespace CoreSystems.Support
             pulse = pulseInterval > 0 && pulseChance > 0 && !ammoDef.Beams.Enable;
         }
 
-        private void AreaEffects(AmmoDef ammoDef, out float areaEffectMaxAbsorb, out float areaEffectMaxDepth, out float detonationMaxDepth, out AreaEffectType areaEffect, out float areaEffectDamage, out double areaEffectSize, out float detonationDamage, out float detonationRadius, out bool ammoAreaEffect, out double areaRadiusSmall, out double areaRadiusLarge, out double detonateRadiusSmall, out double detonateRadiusLarge, out bool eWar, out bool eWarEffect, out double eWarTriggerRange, out int minArmingTime)
+        private void AreaEffects(AmmoDef ammoDef, out float detonationMaxAbsorb, out float areaEffectMaxAbsorb, out float areaEffectMaxDepth, out float detonationMaxDepth, out AreaEffectType areaEffect, out float areaEffectDamage, out double areaEffectSize, out float detonationDamage, out float detonationRadius, out bool ammoAreaEffect, out double areaRadiusSmall, out double areaRadiusLarge, out double detonateRadiusSmall, out double detonateRadiusLarge, out bool eWar, out bool eWarEffect, out double eWarTriggerRange, out int minArmingTime)
         {
             areaEffect = ammoDef.AreaEffect.AreaEffect;
 
@@ -739,7 +741,8 @@ namespace CoreSystems.Support
             //BDC addin for depth & falloff & max absorb
             areaEffectMaxDepth = ammoDef.AreaEffect.AreaEffectMaxDepth <= 0 ? (float)areaEffectSize : ammoDef.AreaEffect.AreaEffectMaxDepth ;
             detonationMaxDepth = ammoDef.AreaEffect.Detonation.DetonationMaxDepth <= 0 ? (float)detonationRadius : ammoDef.AreaEffect.Detonation.DetonationMaxDepth;
-            areaEffectMaxAbsorb = ammoDef.AreaEffect.AreaEffectMaxAbsorb <= 0 ? float.MaxValue : ammoDef.AreaEffect.AreaEffectMaxAbsorb; 
+            areaEffectMaxAbsorb = ammoDef.AreaEffect.AreaEffectMaxAbsorb <= 0 ? float.MaxValue : ammoDef.AreaEffect.AreaEffectMaxAbsorb;
+            detonationMaxAbsorb = ammoDef.AreaEffect.Detonation.DetonationMaxAbsorb <= 0 ? float.MaxValue : ammoDef.AreaEffect.Detonation.DetonationMaxAbsorb;
 
 
             ammoAreaEffect = ammoDef.AreaEffect.AreaEffect != AreaEffectType.Disabled;


### PR DESCRIPTION
Grid damage:
-detmaxabsorb integrated in logic.
-Localpos vs rootblockpos sorted out, blocks>1x1x1 should only take face damage regardless if root or not, and damage radius center no longer dependent on rootblock pos (thx keen)
-error catching/logging watches on index calls

Shield damage:
-proper falloff calcs for detonation applied, limited by maxabsorb.
-proper falloff calcs for radiant area effect applied, also limited by maxabsorb