### PR TITLE
MouseControl fix in menus

### DIFF
--- a/Data/Scripts/CoreSystems/Session/SessionEvents.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionEvents.cs
@@ -423,26 +423,34 @@ namespace CoreSystems
             try
             {
                 InMenu = true;
+                MenuDepth++;
                 Ai ai;
                 if (ActiveControlBlock != null && EntityToMasterAi.TryGetValue(ActiveControlBlock.CubeGrid, out ai))  {
                     //Send updates?
                 }
             }
-            catch (Exception ex) { Log.Line($"Exception in MenuOpened: {ex}", null, true); }
+            catch (Exception ex) { Log.Line($"Exception in MenuOpened: {ex} {MenuDepth}", null, true); }
         }
 
         private void MenuClosed(object obj)
         {
             try
             {
-                InMenu = false;
-                HudUi.NeedsUpdate = true;
-                Ai ai;
-                if (ActiveControlBlock != null && EntityToMasterAi.TryGetValue(ActiveControlBlock.CubeGrid, out ai))  {
-                    //Send updates?
+                MenuDepth--;
+                if (MenuDepth <= 0)
+                {
+                    InMenu = false;
+                    HudUi.NeedsUpdate = true;
+                    Ai ai;
+                    if (ActiveControlBlock != null && EntityToMasterAi.TryGetValue(ActiveControlBlock.CubeGrid, out ai))
+                    {
+                        //Send updates?
+                    }
+                    MenuDepth = 0;//Catch for any keen BS
                 }
+
             }
-            catch (Exception ex) { Log.Line($"Exception in MenuClosed: {ex}", null, true); }
+            catch (Exception ex) { Log.Line($"Exception in MenuClosed: {ex} {MenuDepth}", null, true); }
         }
 
 

--- a/Data/Scripts/CoreSystems/Session/SessionFields.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionFields.cs
@@ -364,6 +364,7 @@ namespace CoreSystems
         internal float ClientSimulation;
         internal bool PurgedAll;
         internal bool InMenu;
+        internal int MenuDepth;
         internal bool GunnerBlackList;
         internal bool MpActive;
         internal bool IsServer;


### PR DESCRIPTION
PBs, and some other blocks, call additional GUIs.  By incrementing and decrementing menu depth we can prevent accidental firing AND prevent locking out mouse control