### PR TITLE
Remappable keys for cycling target selection usable during any mode

### DIFF
--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/CoreSettings.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/CoreSettings.cs
@@ -99,6 +99,7 @@ namespace CoreSystems.Settings
             [ProtoMember(11)] public bool MinimalHud = false;
             [ProtoMember(12)] public bool StikcyPainter = true;
             [ProtoMember(13)] public string CycleKey = MyKeys.PageDown.ToString();
+            [ProtoMember(14)] public string PrevKey = MyKeys.PageUp.ToString();
         }
     }
 }

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/CoreSettings.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/CoreSettings.cs
@@ -98,8 +98,8 @@ namespace CoreSystems.Settings
             [ProtoMember(10)] public string InfoKey = MyKeys.Decimal.ToString();
             [ProtoMember(11)] public bool MinimalHud = false;
             [ProtoMember(12)] public bool StikcyPainter = true;
-            [ProtoMember(10)] public string NextKey = MyKeys.PageDn.ToString();
-            [ProtoMember(10)] public string PrevKey = MyKeys.PageUp.ToString();
+            [ProtoMember(13)] public string NextKey = MyKeys.PageDown.ToString();
+            [ProtoMember(14)] public string PrevKey = MyKeys.PageUp.ToString();
         }
     }
 }

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/CoreSettings.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/CoreSettings.cs
@@ -98,8 +98,7 @@ namespace CoreSystems.Settings
             [ProtoMember(10)] public string InfoKey = MyKeys.Decimal.ToString();
             [ProtoMember(11)] public bool MinimalHud = false;
             [ProtoMember(12)] public bool StikcyPainter = true;
-            [ProtoMember(13)] public string NextKey = MyKeys.PageDown.ToString();
-            [ProtoMember(14)] public string PrevKey = MyKeys.PageUp.ToString();
+            [ProtoMember(13)] public string CycleKey = MyKeys.PageDown.ToString();
         }
     }
 }

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/CoreSettings.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/CoreSettings.cs
@@ -98,8 +98,8 @@ namespace CoreSystems.Settings
             [ProtoMember(10)] public string InfoKey = MyKeys.Decimal.ToString();
             [ProtoMember(11)] public bool MinimalHud = false;
             [ProtoMember(12)] public bool StikcyPainter = true;
-            [ProtoMember(13)] public string CycleNextKey = MyKeys.PageDown.ToString();
-            [ProtoMember(14)] public string CyclePrevKey = MyKeys.PageUp.ToString();
+            [ProtoMember(13)] public string CycleKey = MyKeys.PageDown.ToString();
+            [ProtoMember(14)] public string PrevKey = MyKeys.PageUp.ToString();
         }
     }
 }

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/CoreSettings.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/CoreSettings.cs
@@ -98,6 +98,8 @@ namespace CoreSystems.Settings
             [ProtoMember(10)] public string InfoKey = MyKeys.Decimal.ToString();
             [ProtoMember(11)] public bool MinimalHud = false;
             [ProtoMember(12)] public bool StikcyPainter = true;
+            [ProtoMember(10)] public string NextKey = MyKeys.PageDn.ToString();
+            [ProtoMember(10)] public string PrevKey = MyKeys.PageUp.ToString();
         }
     }
 }

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/CoreSettings.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/CoreSettings.cs
@@ -98,8 +98,8 @@ namespace CoreSystems.Settings
             [ProtoMember(10)] public string InfoKey = MyKeys.Decimal.ToString();
             [ProtoMember(11)] public bool MinimalHud = false;
             [ProtoMember(12)] public bool StikcyPainter = true;
-            [ProtoMember(13)] public string CycleKey = MyKeys.PageDown.ToString();
-            [ProtoMember(14)] public string PrevKey = MyKeys.PageUp.ToString();
+            [ProtoMember(13)] public string CycleNextKey = MyKeys.PageDown.ToString();
+            [ProtoMember(14)] public string CyclePrevKey = MyKeys.PageUp.ToString();
         }
     }
 }

--- a/Data/Scripts/CoreSystems/Session/SessionLocalPlayer.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionLocalPlayer.cs
@@ -48,7 +48,7 @@ namespace CoreSystems
                 TargetUi.SelectTarget(true, UiInput.MouseButtonRightNewPressed);
             else if (!Settings.Enforcement.DisableTargetCycle)
             {
-                if (UiInput.CurrentWheel != UiInput.PreviousWheel && !UiInput.CameraBlockView || UiInput.CycleNextKeyPressed || UiInput.CyclePrevKeyPressed)
+                if (UiInput.CurrentWheel != UiInput.PreviousWheel && !UiInput.CameraBlockView || UiInput.CycleKeyPressed || UiInput.PrevKeyPressed)
                     TargetUi.SelectNext();
             }
 

--- a/Data/Scripts/CoreSystems/Session/SessionLocalPlayer.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionLocalPlayer.cs
@@ -48,7 +48,7 @@ namespace CoreSystems
                 TargetUi.SelectTarget(true, UiInput.MouseButtonRightNewPressed);
             else if (!Settings.Enforcement.DisableTargetCycle)
             {
-                if (UiInput.CurrentWheel != UiInput.PreviousWheel && !UiInput.CameraBlockView || UiInput.CycleKeyPressed || UiInput.PrevKeyPressed)
+                if (UiInput.CurrentWheel != UiInput.PreviousWheel && !UiInput.CameraBlockView || UiInput.CycleNextKeyPressed || UiInput.CyclePrevKeyPressed)
                     TargetUi.SelectNext();
             }
 

--- a/Data/Scripts/CoreSystems/Session/SessionLocalPlayer.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionLocalPlayer.cs
@@ -46,12 +46,11 @@ namespace CoreSystems
 
             if (UiInput.MouseButtonRightNewPressed || UiInput.MouseButtonRightReleased && (TargetUi.DrawReticle || UiInput.FirstPersonView))
                 TargetUi.SelectTarget(true, UiInput.MouseButtonRightNewPressed);
-            else if (!UiInput.CameraBlockView)
+            else if (!Settings.Enforcement.DisableTargetCycle)
             {
-                if (UiInput.CurrentWheel != UiInput.PreviousWheel && !Settings.Enforcement.DisableTargetCycle)
+                if (UiInput.CurrentWheel != UiInput.PreviousWheel && !UiInput.CameraBlockView || UiInput.CycleKeyPressed || UiInput.PrevKeyPressed)
                     TargetUi.SelectNext();
             }
-            if (UiInput.CycleKeyPressed && !Settings.Enforcement.DisableTargetCycle) TargetUi.SelectNext();
 
         }
 

--- a/Data/Scripts/CoreSystems/Session/SessionLocalPlayer.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionLocalPlayer.cs
@@ -51,6 +51,8 @@ namespace CoreSystems
                 if (UiInput.CurrentWheel != UiInput.PreviousWheel && !Settings.Enforcement.DisableTargetCycle)
                     TargetUi.SelectNext();
             }
+            if (UiInput.CycleKeyPressed && !Settings.Enforcement.DisableTargetCycle) TargetUi.SelectNext();
+
         }
 
 

--- a/Data/Scripts/CoreSystems/Session/SessionSupport.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionSupport.cs
@@ -524,6 +524,36 @@ namespace CoreSystems
                     ControlRequest = ControlQuery.None;
                 }
             }
+            else if (ControlRequest == ControlQuery.Next)
+            {
+
+                MyAPIGateway.Input.GetListOfPressedKeys(_pressedKeys);
+                if (_pressedKeys.Count > 0 && _pressedKeys[0] != MyKeys.Enter)
+                {
+
+                    var firstKey = _pressedKeys[0];
+                    Settings.ClientConfig.NextKey = firstKey.ToString();
+                    UiInput.NextKey = firstKey;
+                    ControlRequest = ControlQuery.None;
+                    Settings.VersionControl.UpdateClientCfgFile();
+                    MyAPIGateway.Utilities.ShowNotification($"{firstKey.ToString()} is now the extra Next Target Key", 10000);
+                }
+            }
+            else if (ControlRequest == ControlQuery.Prev)
+            {
+
+                MyAPIGateway.Input.GetListOfPressedKeys(_pressedKeys);
+                if (_pressedKeys.Count > 0 && _pressedKeys[0] != MyKeys.Enter)
+                {
+
+                    var firstKey = _pressedKeys[0];
+                    Settings.ClientConfig.PrevKey = firstKey.ToString();
+                    UiInput.PrevKey = firstKey;
+                    ControlRequest = ControlQuery.None;
+                    Settings.VersionControl.UpdateClientCfgFile();
+                    MyAPIGateway.Utilities.ShowNotification($"{firstKey.ToString()} is now the extra Previous Target Key", 10000);
+                }
+            }
             _pressedKeys.Clear();
             _pressedButtons.Clear();
         }
@@ -556,6 +586,16 @@ namespace CoreSystems
                         ControlRequest = ControlQuery.Info;
                         somethingUpdated = true;
                         MyAPIGateway.Utilities.ShowNotification($"Press the key you want to use for the WeaponCore Info key", 10000);
+                        break;
+                    case "/wc remap next":
+                        ControlRequest = ControlQuery.Next;
+                        somethingUpdated = true;
+                        MyAPIGateway.Utilities.ShowNotification($"Press the key you want to use for Next Target Selection", 10000);
+                        break;
+                    case "/wc remap prev":
+                        ControlRequest = ControlQuery.Prev;
+                        somethingUpdated = true;
+                        MyAPIGateway.Utilities.ShowNotification($"Press the key you want to use for Previous Target Selection", 10000);
                         break;
                 }
 
@@ -610,7 +650,7 @@ namespace CoreSystems
                     if (message.Length <= 3)
                         MyAPIGateway.Utilities.ShowNotification("Valid WeaponCore Commands:\n'/wc remap -- Remap keys'\n'/wc drawlimit 1000' -- Limits total number of projectiles on screen (default unlimited)\n'/wc changehud' to enable moving/resizing of WC Hud\n'/wc setdefaults' -- Resets shield client configs to default values\n'/wc stickypainter' -- Disable Painter LoS checks\n", 10000);
                     else if (message.StartsWith("/wc remap"))
-                        MyAPIGateway.Utilities.ShowNotification("'/wc remap keyboard' -- Remaps control key (default R)\n'/wc remap mouse' -- Remaps menu mouse key (default middle button)\n'/wc remap action' -- Remaps action key (default numpad0)\n'/wc remap info' -- Remaps info key (default decimal key, aka numpad period key)\n", 10000, "White");
+                        MyAPIGateway.Utilities.ShowNotification("'/wc remap keyboard' -- Remaps control key (default R)\n'/wc remap mouse' -- Remaps menu mouse key (default middle button)\n'/wc remap action' -- Remaps action key (default numpad0)\n'/wc remap info' -- Remaps info key (default decimal key, aka numpad period key)\n'/wc remap next' -- Remaps an extra Next Target key (default mousewheel down)\n'/wc remap prev' -- Remaps an extra Previous Target key (default mousewheel up)\n", 10000, "White");
                 }
                 sendToOthers = false;
             }

--- a/Data/Scripts/CoreSystems/Session/SessionSupport.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionSupport.cs
@@ -524,7 +524,7 @@ namespace CoreSystems
                     ControlRequest = ControlQuery.None;
                 }
             }
-            else if (ControlRequest == ControlQuery.Next)
+            else if (ControlRequest == ControlQuery.Cycle)
             {
 
                 MyAPIGateway.Input.GetListOfPressedKeys(_pressedKeys);
@@ -532,11 +532,11 @@ namespace CoreSystems
                 {
 
                     var firstKey = _pressedKeys[0];
-                    Settings.ClientConfig.CycleNextKey = firstKey.ToString();
-                    UiInput.CycleNextKey = firstKey;
+                    Settings.ClientConfig.CycleKey = firstKey.ToString();
+                    UiInput.CycleKey = firstKey;
                     ControlRequest = ControlQuery.None;
                     Settings.VersionControl.UpdateClientCfgFile();
-                    MyAPIGateway.Utilities.ShowNotification($"{firstKey.ToString()} is now the Cycle Next Target Key", 10000);
+                    MyAPIGateway.Utilities.ShowNotification($"{firstKey.ToString()} is now the Cycle Target Key", 10000);
                 }
             }
             else if (ControlRequest == ControlQuery.Prev)
@@ -547,8 +547,8 @@ namespace CoreSystems
                 {
 
                     var firstKey = _pressedKeys[0];
-                    Settings.ClientConfig.CyclePrevKey = firstKey.ToString();
-                    UiInput.CyclePrevKey = firstKey;
+                    Settings.ClientConfig.PrevKey = firstKey.ToString();
+                    UiInput.PrevKey = firstKey;
                     ControlRequest = ControlQuery.None;
                     Settings.VersionControl.UpdateClientCfgFile();
                     MyAPIGateway.Utilities.ShowNotification($"{firstKey.ToString()} is now the Cycle Previous Target Key", 10000);
@@ -587,8 +587,8 @@ namespace CoreSystems
                         somethingUpdated = true;
                         MyAPIGateway.Utilities.ShowNotification($"Press the key you want to use for the WeaponCore Info key", 10000);
                         break;
-                    case "/wc remap next":
-                        ControlRequest = ControlQuery.Next;
+                    case "/wc remap cycle":
+                        ControlRequest = ControlQuery.Cycle;
                         somethingUpdated = true;
                         MyAPIGateway.Utilities.ShowNotification($"Press the key you want to use for Cycling Next Target Selection", 10000);
                         break;
@@ -650,7 +650,7 @@ namespace CoreSystems
                     if (message.Length <= 3)
                         MyAPIGateway.Utilities.ShowNotification("Valid WeaponCore Commands:\n'/wc remap -- Remap keys'\n'/wc drawlimit 1000' -- Limits total number of projectiles on screen (default unlimited)\n'/wc changehud' to enable moving/resizing of WC Hud\n'/wc setdefaults' -- Resets shield client configs to default values\n'/wc stickypainter' -- Disable Painter LoS checks\n", 10000);
                     else if (message.StartsWith("/wc remap"))
-                        MyAPIGateway.Utilities.ShowNotification("'/wc remap keyboard' -- Remaps control key (default R)\n'/wc remap mouse' -- Remaps menu mouse key (default middle button)\n'/wc remap action' -- Remaps action key (default numpad0)\n'/wc remap info' -- Remaps info key (default decimal key, aka numpad period key)\n'/wc remap next' -- Remaps the Cycle Next Target key (default Page Down)\n'/wc remap prev' -- Remaps the Cycle Previous Target key (default Page Up)\n", 10000, "White");
+                        MyAPIGateway.Utilities.ShowNotification("'/wc remap keyboard' -- Remaps control key (default R)\n'/wc remap mouse' -- Remaps menu mouse key (default middle button)\n'/wc remap action' -- Remaps action key (default numpad0)\n'/wc remap info' -- Remaps info key (default decimal key, aka numpad period key)\n'/wc remap cycle' -- Remaps the Cycle Next Target key (default Page Down)\n'/wc remap prev' -- Remaps the Cycle Previous Target key (default Page Up)\n", 10000, "White");
                 }
                 sendToOthers = false;
             }

--- a/Data/Scripts/CoreSystems/Session/SessionSupport.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionSupport.cs
@@ -524,7 +524,7 @@ namespace CoreSystems
                     ControlRequest = ControlQuery.None;
                 }
             }
-            else if (ControlRequest == ControlQuery.Next)
+            else if (ControlRequest == ControlQuery.Cycle)
             {
 
                 MyAPIGateway.Input.GetListOfPressedKeys(_pressedKeys);
@@ -532,26 +532,11 @@ namespace CoreSystems
                 {
 
                     var firstKey = _pressedKeys[0];
-                    Settings.ClientConfig.NextKey = firstKey.ToString();
-                    UiInput.NextKey = firstKey;
+                    Settings.ClientConfig.CycleKey = firstKey.ToString();
+                    UiInput.CycleKey = firstKey;
                     ControlRequest = ControlQuery.None;
                     Settings.VersionControl.UpdateClientCfgFile();
-                    MyAPIGateway.Utilities.ShowNotification($"{firstKey.ToString()} is now the extra Next Target Key", 10000);
-                }
-            }
-            else if (ControlRequest == ControlQuery.Prev)
-            {
-
-                MyAPIGateway.Input.GetListOfPressedKeys(_pressedKeys);
-                if (_pressedKeys.Count > 0 && _pressedKeys[0] != MyKeys.Enter)
-                {
-
-                    var firstKey = _pressedKeys[0];
-                    Settings.ClientConfig.PrevKey = firstKey.ToString();
-                    UiInput.PrevKey = firstKey;
-                    ControlRequest = ControlQuery.None;
-                    Settings.VersionControl.UpdateClientCfgFile();
-                    MyAPIGateway.Utilities.ShowNotification($"{firstKey.ToString()} is now the extra Previous Target Key", 10000);
+                    MyAPIGateway.Utilities.ShowNotification($"{firstKey.ToString()} is now the Cycle Target Key", 10000);
                 }
             }
             _pressedKeys.Clear();
@@ -587,15 +572,10 @@ namespace CoreSystems
                         somethingUpdated = true;
                         MyAPIGateway.Utilities.ShowNotification($"Press the key you want to use for the WeaponCore Info key", 10000);
                         break;
-                    case "/wc remap next":
-                        ControlRequest = ControlQuery.Next;
+                    case "/wc remap cycle":
+                        ControlRequest = ControlQuery.Cycle;
                         somethingUpdated = true;
-                        MyAPIGateway.Utilities.ShowNotification($"Press the key you want to use for Next Target Selection", 10000);
-                        break;
-                    case "/wc remap prev":
-                        ControlRequest = ControlQuery.Prev;
-                        somethingUpdated = true;
-                        MyAPIGateway.Utilities.ShowNotification($"Press the key you want to use for Previous Target Selection", 10000);
+                        MyAPIGateway.Utilities.ShowNotification($"Press the key you want to use for Cycling Target Selection", 10000);
                         break;
                 }
 
@@ -650,7 +630,7 @@ namespace CoreSystems
                     if (message.Length <= 3)
                         MyAPIGateway.Utilities.ShowNotification("Valid WeaponCore Commands:\n'/wc remap -- Remap keys'\n'/wc drawlimit 1000' -- Limits total number of projectiles on screen (default unlimited)\n'/wc changehud' to enable moving/resizing of WC Hud\n'/wc setdefaults' -- Resets shield client configs to default values\n'/wc stickypainter' -- Disable Painter LoS checks\n", 10000);
                     else if (message.StartsWith("/wc remap"))
-                        MyAPIGateway.Utilities.ShowNotification("'/wc remap keyboard' -- Remaps control key (default R)\n'/wc remap mouse' -- Remaps menu mouse key (default middle button)\n'/wc remap action' -- Remaps action key (default numpad0)\n'/wc remap info' -- Remaps info key (default decimal key, aka numpad period key)\n'/wc remap next' -- Remaps an extra Next Target key (default mousewheel down)\n'/wc remap prev' -- Remaps an extra Previous Target key (default mousewheel up)\n", 10000, "White");
+                        MyAPIGateway.Utilities.ShowNotification("'/wc remap keyboard' -- Remaps control key (default R)\n'/wc remap mouse' -- Remaps menu mouse key (default middle button)\n'/wc remap action' -- Remaps action key (default numpad0)\n'/wc remap info' -- Remaps info key (default decimal key, aka numpad period key)\n'/wc remap cycle' -- Remaps the Cycle Target key (default Page Down)\n", 10000, "White");
                 }
                 sendToOthers = false;
             }

--- a/Data/Scripts/CoreSystems/Session/SessionSupport.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionSupport.cs
@@ -524,7 +524,7 @@ namespace CoreSystems
                     ControlRequest = ControlQuery.None;
                 }
             }
-            else if (ControlRequest == ControlQuery.Cycle)
+            else if (ControlRequest == ControlQuery.Next)
             {
 
                 MyAPIGateway.Input.GetListOfPressedKeys(_pressedKeys);
@@ -532,11 +532,11 @@ namespace CoreSystems
                 {
 
                     var firstKey = _pressedKeys[0];
-                    Settings.ClientConfig.CycleKey = firstKey.ToString();
-                    UiInput.CycleKey = firstKey;
+                    Settings.ClientConfig.CycleNextKey = firstKey.ToString();
+                    UiInput.CycleNextKey = firstKey;
                     ControlRequest = ControlQuery.None;
                     Settings.VersionControl.UpdateClientCfgFile();
-                    MyAPIGateway.Utilities.ShowNotification($"{firstKey.ToString()} is now the Cycle Target Key", 10000);
+                    MyAPIGateway.Utilities.ShowNotification($"{firstKey.ToString()} is now the Cycle Next Target Key", 10000);
                 }
             }
             else if (ControlRequest == ControlQuery.Prev)
@@ -547,8 +547,8 @@ namespace CoreSystems
                 {
 
                     var firstKey = _pressedKeys[0];
-                    Settings.ClientConfig.PrevKey = firstKey.ToString();
-                    UiInput.PrevKey = firstKey;
+                    Settings.ClientConfig.CyclePrevKey = firstKey.ToString();
+                    UiInput.CyclePrevKey = firstKey;
                     ControlRequest = ControlQuery.None;
                     Settings.VersionControl.UpdateClientCfgFile();
                     MyAPIGateway.Utilities.ShowNotification($"{firstKey.ToString()} is now the Cycle Previous Target Key", 10000);
@@ -587,8 +587,8 @@ namespace CoreSystems
                         somethingUpdated = true;
                         MyAPIGateway.Utilities.ShowNotification($"Press the key you want to use for the WeaponCore Info key", 10000);
                         break;
-                    case "/wc remap cycle":
-                        ControlRequest = ControlQuery.Cycle;
+                    case "/wc remap next":
+                        ControlRequest = ControlQuery.Next;
                         somethingUpdated = true;
                         MyAPIGateway.Utilities.ShowNotification($"Press the key you want to use for Cycling Next Target Selection", 10000);
                         break;
@@ -650,7 +650,7 @@ namespace CoreSystems
                     if (message.Length <= 3)
                         MyAPIGateway.Utilities.ShowNotification("Valid WeaponCore Commands:\n'/wc remap -- Remap keys'\n'/wc drawlimit 1000' -- Limits total number of projectiles on screen (default unlimited)\n'/wc changehud' to enable moving/resizing of WC Hud\n'/wc setdefaults' -- Resets shield client configs to default values\n'/wc stickypainter' -- Disable Painter LoS checks\n", 10000);
                     else if (message.StartsWith("/wc remap"))
-                        MyAPIGateway.Utilities.ShowNotification("'/wc remap keyboard' -- Remaps control key (default R)\n'/wc remap mouse' -- Remaps menu mouse key (default middle button)\n'/wc remap action' -- Remaps action key (default numpad0)\n'/wc remap info' -- Remaps info key (default decimal key, aka numpad period key)\n'/wc remap cycle' -- Remaps the Cycle Next Target key (default Page Down)\n'/wc remap prev' -- Remaps the Cycle Previous Target key (default Page Up)\n", 10000, "White");
+                        MyAPIGateway.Utilities.ShowNotification("'/wc remap keyboard' -- Remaps control key (default R)\n'/wc remap mouse' -- Remaps menu mouse key (default middle button)\n'/wc remap action' -- Remaps action key (default numpad0)\n'/wc remap info' -- Remaps info key (default decimal key, aka numpad period key)\n'/wc remap next' -- Remaps the Cycle Next Target key (default Page Down)\n'/wc remap prev' -- Remaps the Cycle Previous Target key (default Page Up)\n", 10000, "White");
                 }
                 sendToOthers = false;
             }

--- a/Data/Scripts/CoreSystems/Session/SessionSupport.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionSupport.cs
@@ -539,6 +539,21 @@ namespace CoreSystems
                     MyAPIGateway.Utilities.ShowNotification($"{firstKey.ToString()} is now the Cycle Target Key", 10000);
                 }
             }
+            else if (ControlRequest == ControlQuery.Prev)
+            {
+
+                MyAPIGateway.Input.GetListOfPressedKeys(_pressedKeys);
+                if (_pressedKeys.Count > 0 && _pressedKeys[0] != MyKeys.Enter)
+                {
+
+                    var firstKey = _pressedKeys[0];
+                    Settings.ClientConfig.PrevKey = firstKey.ToString();
+                    UiInput.PrevKey = firstKey;
+                    ControlRequest = ControlQuery.None;
+                    Settings.VersionControl.UpdateClientCfgFile();
+                    MyAPIGateway.Utilities.ShowNotification($"{firstKey.ToString()} is now the Cycle Previous Target Key", 10000);
+                }
+            }
             _pressedKeys.Clear();
             _pressedButtons.Clear();
         }
@@ -575,7 +590,12 @@ namespace CoreSystems
                     case "/wc remap cycle":
                         ControlRequest = ControlQuery.Cycle;
                         somethingUpdated = true;
-                        MyAPIGateway.Utilities.ShowNotification($"Press the key you want to use for Cycling Target Selection", 10000);
+                        MyAPIGateway.Utilities.ShowNotification($"Press the key you want to use for Cycling Next Target Selection", 10000);
+                        break;
+                    case "/wc remap prev":
+                        ControlRequest = ControlQuery.Prev;
+                        somethingUpdated = true;
+                        MyAPIGateway.Utilities.ShowNotification($"Press the key you want to use for Cycling Previous Target Selection", 10000);
                         break;
                 }
 
@@ -630,7 +650,7 @@ namespace CoreSystems
                     if (message.Length <= 3)
                         MyAPIGateway.Utilities.ShowNotification("Valid WeaponCore Commands:\n'/wc remap -- Remap keys'\n'/wc drawlimit 1000' -- Limits total number of projectiles on screen (default unlimited)\n'/wc changehud' to enable moving/resizing of WC Hud\n'/wc setdefaults' -- Resets shield client configs to default values\n'/wc stickypainter' -- Disable Painter LoS checks\n", 10000);
                     else if (message.StartsWith("/wc remap"))
-                        MyAPIGateway.Utilities.ShowNotification("'/wc remap keyboard' -- Remaps control key (default R)\n'/wc remap mouse' -- Remaps menu mouse key (default middle button)\n'/wc remap action' -- Remaps action key (default numpad0)\n'/wc remap info' -- Remaps info key (default decimal key, aka numpad period key)\n'/wc remap cycle' -- Remaps the Cycle Target key (default Page Down)\n", 10000, "White");
+                        MyAPIGateway.Utilities.ShowNotification("'/wc remap keyboard' -- Remaps control key (default R)\n'/wc remap mouse' -- Remaps menu mouse key (default middle button)\n'/wc remap action' -- Remaps action key (default numpad0)\n'/wc remap info' -- Remaps info key (default decimal key, aka numpad period key)\n'/wc remap cycle' -- Remaps the Cycle Next Target key (default Page Down)\n'/wc remap prev' -- Remaps the Cycle Previous Target key (default Page Up)\n", 10000, "White");
                 }
                 sendToOthers = false;
             }

--- a/Data/Scripts/CoreSystems/Session/SessionTypes.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionTypes.cs
@@ -862,6 +862,8 @@ namespace CoreSystems
             Action,
             Info,
             Mouse,
+            Next,
+            Prev,
         }
 
         internal struct BlockDamage

--- a/Data/Scripts/CoreSystems/Session/SessionTypes.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionTypes.cs
@@ -862,7 +862,7 @@ namespace CoreSystems
             Action,
             Info,
             Mouse,
-            Cycle,
+            Next,
             Prev,
         }
 

--- a/Data/Scripts/CoreSystems/Session/SessionTypes.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionTypes.cs
@@ -863,6 +863,7 @@ namespace CoreSystems
             Info,
             Mouse,
             Cycle,
+            Prev,
         }
 
         internal struct BlockDamage

--- a/Data/Scripts/CoreSystems/Session/SessionTypes.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionTypes.cs
@@ -862,7 +862,7 @@ namespace CoreSystems
             Action,
             Info,
             Mouse,
-            Next,
+            Cycle,
             Prev,
         }
 

--- a/Data/Scripts/CoreSystems/Session/SessionTypes.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionTypes.cs
@@ -862,8 +862,7 @@ namespace CoreSystems
             Action,
             Info,
             Mouse,
-            Next,
-            Prev,
+            Cycle,
         }
 
         internal struct BlockDamage

--- a/Data/Scripts/CoreSystems/Support/VersionControl.cs
+++ b/Data/Scripts/CoreSystems/Support/VersionControl.cs
@@ -37,6 +37,7 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Support
                     Core.Session.UiInput.MouseButtonMenu = Core.Session.MouseMap[xmlData.MenuButton];
                     Core.Session.UiInput.InfoKey = Core.Session.KeyMap[xmlData.InfoKey];
                     Core.Session.UiInput.CycleKey = Core.Session.KeyMap[xmlData.CycleKey];
+                    Core.Session.UiInput.PrevKey = Core.Session.KeyMap[xmlData.PrevKey];
                 }
                 else
                     WriteNewClientCfg();

--- a/Data/Scripts/CoreSystems/Support/VersionControl.cs
+++ b/Data/Scripts/CoreSystems/Support/VersionControl.cs
@@ -36,6 +36,8 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Support
                     Core.Session.UiInput.ActionKey = Core.Session.KeyMap[xmlData.ActionKey];
                     Core.Session.UiInput.MouseButtonMenu = Core.Session.MouseMap[xmlData.MenuButton];
                     Core.Session.UiInput.InfoKey = Core.Session.KeyMap[xmlData.InfoKey];
+                    Core.Session.UiInput.NextKey = Core.Session.KeyMap[xmlData.NextKey];
+                    Core.Session.UiInput.PrevKey = Core.Session.KeyMap[xmlData.PrevKey];
                 }
                 else
                     WriteNewClientCfg();

--- a/Data/Scripts/CoreSystems/Support/VersionControl.cs
+++ b/Data/Scripts/CoreSystems/Support/VersionControl.cs
@@ -36,8 +36,8 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Support
                     Core.Session.UiInput.ActionKey = Core.Session.KeyMap[xmlData.ActionKey];
                     Core.Session.UiInput.MouseButtonMenu = Core.Session.MouseMap[xmlData.MenuButton];
                     Core.Session.UiInput.InfoKey = Core.Session.KeyMap[xmlData.InfoKey];
-                    Core.Session.UiInput.CycleKey = Core.Session.KeyMap[xmlData.CycleKey];
-                    Core.Session.UiInput.PrevKey = Core.Session.KeyMap[xmlData.PrevKey];
+                    Core.Session.UiInput.CycleNextKey = Core.Session.KeyMap[xmlData.CycleNextKey];
+                    Core.Session.UiInput.CyclePrevKey = Core.Session.KeyMap[xmlData.CyclePrevKey];
                 }
                 else
                     WriteNewClientCfg();

--- a/Data/Scripts/CoreSystems/Support/VersionControl.cs
+++ b/Data/Scripts/CoreSystems/Support/VersionControl.cs
@@ -36,8 +36,7 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Support
                     Core.Session.UiInput.ActionKey = Core.Session.KeyMap[xmlData.ActionKey];
                     Core.Session.UiInput.MouseButtonMenu = Core.Session.MouseMap[xmlData.MenuButton];
                     Core.Session.UiInput.InfoKey = Core.Session.KeyMap[xmlData.InfoKey];
-                    Core.Session.UiInput.NextKey = Core.Session.KeyMap[xmlData.NextKey];
-                    Core.Session.UiInput.PrevKey = Core.Session.KeyMap[xmlData.PrevKey];
+                    Core.Session.UiInput.CycleKey = Core.Session.KeyMap[xmlData.CycleKey];
                 }
                 else
                     WriteNewClientCfg();

--- a/Data/Scripts/CoreSystems/Support/VersionControl.cs
+++ b/Data/Scripts/CoreSystems/Support/VersionControl.cs
@@ -36,8 +36,8 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Support
                     Core.Session.UiInput.ActionKey = Core.Session.KeyMap[xmlData.ActionKey];
                     Core.Session.UiInput.MouseButtonMenu = Core.Session.MouseMap[xmlData.MenuButton];
                     Core.Session.UiInput.InfoKey = Core.Session.KeyMap[xmlData.InfoKey];
-                    Core.Session.UiInput.CycleNextKey = Core.Session.KeyMap[xmlData.CycleNextKey];
-                    Core.Session.UiInput.CyclePrevKey = Core.Session.KeyMap[xmlData.CyclePrevKey];
+                    Core.Session.UiInput.CycleKey = Core.Session.KeyMap[xmlData.CycleKey];
+                    Core.Session.UiInput.PrevKey = Core.Session.KeyMap[xmlData.PrevKey];
                 }
                 else
                     WriteNewClientCfg();

--- a/Data/Scripts/CoreSystems/Ui/Targeting/TargetUiSelect.cs
+++ b/Data/Scripts/CoreSystems/Ui/Targeting/TargetUiSelect.cs
@@ -281,22 +281,18 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui.Targeting
 
             var canMoveForward = _currentIdx + 1 <= _endIdx;
             var canMoveBackward = _currentIdx - 1 >= 0;
-            if (s.UiInput.WheelForward)
+            if (s.UiInput.WheelForward || s.UiInput.CycleKeyPressed)
+            {
                 if (canMoveForward)
                     _currentIdx += 1;
                 else _currentIdx = 0;
+            }
             else if (s.UiInput.WheelBackward)
+            {
                 if (canMoveBackward)
                     _currentIdx -= 1;
                 else _currentIdx = _endIdx;
-            else if (s.UiInput.NextKeyPressed)
-                if (canMoveForward)
-                    _currentIdx += 1;
-                else _currentIdx = 0;
-            else if (s.UiInput.PrevKeyPressed)
-                if (canMoveBackward)
-                    _currentIdx -= 1;
-                else _currentIdx = _endIdx;
+            }
 
             var ent = _sortedMasterList[_currentIdx];
             if (ent == null || ent.MarkedForClose || ai.NoTargetLos.ContainsKey(ent))

--- a/Data/Scripts/CoreSystems/Ui/Targeting/TargetUiSelect.cs
+++ b/Data/Scripts/CoreSystems/Ui/Targeting/TargetUiSelect.cs
@@ -281,11 +281,11 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui.Targeting
 
             var canMoveForward = _currentIdx + 1 <= _endIdx;
             var canMoveBackward = _currentIdx - 1 >= 0;
-            if (s.UiInput.WheelForward || s.UiInput.CycleNextKeyPressed)
+            if (s.UiInput.WheelForward || s.UiInput.CycleKeyPressed)
                 if (canMoveForward)
                     _currentIdx += 1;
                 else _currentIdx = 0;
-            else if (s.UiInput.WheelBackward || s.UiInput.CyclePrevKeyPressed)
+            else if (s.UiInput.WheelBackward || s.UiInput.PrevKeyPressed)
                 if (canMoveBackward)
                     _currentIdx -= 1;
                 else _currentIdx = _endIdx;

--- a/Data/Scripts/CoreSystems/Ui/Targeting/TargetUiSelect.cs
+++ b/Data/Scripts/CoreSystems/Ui/Targeting/TargetUiSelect.cs
@@ -289,11 +289,11 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui.Targeting
                 if (canMoveBackward)
                     _currentIdx -= 1;
                 else _currentIdx = _endIdx;
-            else if (s.UiInput.NextKey)
+            else if (s.UiInput.NextKeyPressed)
                 if (canMoveForward)
                     _currentIdx += 1;
                 else _currentIdx = 0;
-            else if (s.UiInput.PrevKey)
+            else if (s.UiInput.PrevKeyPressed)
                 if (canMoveBackward)
                     _currentIdx -= 1;
                 else _currentIdx = _endIdx;

--- a/Data/Scripts/CoreSystems/Ui/Targeting/TargetUiSelect.cs
+++ b/Data/Scripts/CoreSystems/Ui/Targeting/TargetUiSelect.cs
@@ -289,6 +289,14 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui.Targeting
                 if (canMoveBackward)
                     _currentIdx -= 1;
                 else _currentIdx = _endIdx;
+            else if (s.UiInput.NextKey)
+                if (canMoveForward)
+                    _currentIdx += 1;
+                else _currentIdx = 0;
+            else if (s.UiInput.PrevKey)
+                if (canMoveBackward)
+                    _currentIdx -= 1;
+                else _currentIdx = _endIdx;
 
             var ent = _sortedMasterList[_currentIdx];
             if (ent == null || ent.MarkedForClose || ai.NoTargetLos.ContainsKey(ent))

--- a/Data/Scripts/CoreSystems/Ui/Targeting/TargetUiSelect.cs
+++ b/Data/Scripts/CoreSystems/Ui/Targeting/TargetUiSelect.cs
@@ -281,11 +281,11 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui.Targeting
 
             var canMoveForward = _currentIdx + 1 <= _endIdx;
             var canMoveBackward = _currentIdx - 1 >= 0;
-            if (s.UiInput.WheelForward || s.UiInput.CycleKeyPressed)
+            if (s.UiInput.WheelForward || s.UiInput.CycleNextKeyPressed)
                 if (canMoveForward)
                     _currentIdx += 1;
                 else _currentIdx = 0;
-            else if (s.UiInput.WheelBackward || s.UiInput.PrevKeyPressed)
+            else if (s.UiInput.WheelBackward || s.UiInput.CyclePrevKeyPressed)
                 if (canMoveBackward)
                     _currentIdx -= 1;
                 else _currentIdx = _endIdx;

--- a/Data/Scripts/CoreSystems/Ui/Targeting/TargetUiSelect.cs
+++ b/Data/Scripts/CoreSystems/Ui/Targeting/TargetUiSelect.cs
@@ -282,17 +282,13 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui.Targeting
             var canMoveForward = _currentIdx + 1 <= _endIdx;
             var canMoveBackward = _currentIdx - 1 >= 0;
             if (s.UiInput.WheelForward || s.UiInput.CycleKeyPressed)
-            {
                 if (canMoveForward)
                     _currentIdx += 1;
                 else _currentIdx = 0;
-            }
             else if (s.UiInput.WheelBackward)
-            {
                 if (canMoveBackward)
                     _currentIdx -= 1;
                 else _currentIdx = _endIdx;
-            }
 
             var ent = _sortedMasterList[_currentIdx];
             if (ent == null || ent.MarkedForClose || ai.NoTargetLos.ContainsKey(ent))

--- a/Data/Scripts/CoreSystems/Ui/Targeting/TargetUiSelect.cs
+++ b/Data/Scripts/CoreSystems/Ui/Targeting/TargetUiSelect.cs
@@ -285,7 +285,7 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui.Targeting
                 if (canMoveForward)
                     _currentIdx += 1;
                 else _currentIdx = 0;
-            else if (s.UiInput.WheelBackward)
+            else if (s.UiInput.WheelBackward || s.UiInput.PrevKeyPressed)
                 if (canMoveBackward)
                     _currentIdx -= 1;
                 else _currentIdx = _endIdx;

--- a/Data/Scripts/CoreSystems/Ui/UiInput.cs
+++ b/Data/Scripts/CoreSystems/Ui/UiInput.cs
@@ -267,10 +267,7 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
                 CycleKeyPressed = true;
                 CycleKeyReleased = false;
             }
-            if (MyAPIGateway.Input.IsNewKeyReleased(CycleKey))
-            {
-                CycleKeyReleased = true;
-            }
+            if (MyAPIGateway.Input.IsNewKeyReleased(CycleKey)) CycleKeyReleased = true;
 
             if (!ActionKeyPressed && BlackListActive1)
                 BlackList1(false);

--- a/Data/Scripts/CoreSystems/Ui/UiInput.cs
+++ b/Data/Scripts/CoreSystems/Ui/UiInput.cs
@@ -26,10 +26,10 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
         internal bool WasInMenu;
         internal bool WheelForward;
         internal bool WheelBackward;
-        internal bool CycleNextKeyPressed;
-        internal bool CycleNextKeyReleased;
-        internal bool CyclePrevKeyPressed;
-        internal bool CyclePrevKeyReleased;
+        internal bool CycleKeyPressed;
+        internal bool CycleKeyReleased;
+        internal bool PrevKeyPressed;
+        internal bool PrevKeyReleased;
         internal bool ShiftReleased;
         internal bool ShiftPressed;
         internal bool LongShift;
@@ -60,8 +60,8 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
         internal MyKeys ControlKey;
         internal MyKeys ActionKey;
         internal MyKeys InfoKey;
-        internal MyKeys CycleNextKey;
-        internal MyKeys CyclePrevKey;
+        internal MyKeys CycleKey;
+        internal MyKeys PrevKey;
 
         internal MyMouseButtonsEnum MouseButtonMenu;
 
@@ -77,8 +77,8 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
             WheelForward = false;
             WheelBackward = false;
             AimRay = new LineD();
-            CycleNextKeyPressed = false;
-            CyclePrevKeyPressed = false;
+            CycleKeyPressed = false;
+            PrevKeyPressed = false;
 
             if (!s.InGridAiBlock) s.UpdateLocalAiAndCockpit();
 
@@ -266,19 +266,19 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
             else if (s.UiInput.CurrentWheel != s.UiInput.PreviousWheel)
                 WheelBackward = true;
 
-            if (MyAPIGateway.Input.IsKeyPress(CycleNextKey) && CycleNextKeyReleased)
+            if (MyAPIGateway.Input.IsKeyPress(CycleKey) && CycleKeyReleased)
             {
-                CycleNextKeyPressed = true;
-                CycleNextKeyReleased = false;
+                CycleKeyPressed = true;
+                CycleKeyReleased = false;
             }
-            if (MyAPIGateway.Input.IsNewKeyReleased(CycleNextKey)) CycleNextKeyReleased = true;
+            if (MyAPIGateway.Input.IsNewKeyReleased(CycleKey)) CycleKeyReleased = true;
 
-            if (MyAPIGateway.Input.IsKeyPress(CyclePrevKey) && CyclePrevKeyReleased)
+            if (MyAPIGateway.Input.IsKeyPress(PrevKey) && PrevKeyReleased)
             {
-                CyclePrevKeyPressed = true;
-                CyclePrevKeyReleased = false;
+                PrevKeyPressed = true;
+                PrevKeyReleased = false;
             }
-            if (MyAPIGateway.Input.IsNewKeyReleased(CyclePrevKey)) CyclePrevKeyReleased = true;
+            if (MyAPIGateway.Input.IsNewKeyReleased(PrevKey)) PrevKeyReleased = true;
 
             if (!ActionKeyPressed && BlackListActive1)
                 BlackList1(false);

--- a/Data/Scripts/CoreSystems/Ui/UiInput.cs
+++ b/Data/Scripts/CoreSystems/Ui/UiInput.cs
@@ -26,10 +26,10 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
         internal bool WasInMenu;
         internal bool WheelForward;
         internal bool WheelBackward;
-        internal bool CycleKeyPressed;
-        internal bool CycleKeyReleased;
-        internal bool PrevKeyPressed;
-        internal bool PrevKeyReleased;
+        internal bool CycleNextKeyPressed;
+        internal bool CycleNextKeyReleased;
+        internal bool CyclePrevKeyPressed;
+        internal bool CyclePrevKeyReleased;
         internal bool ShiftReleased;
         internal bool ShiftPressed;
         internal bool LongShift;
@@ -60,8 +60,8 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
         internal MyKeys ControlKey;
         internal MyKeys ActionKey;
         internal MyKeys InfoKey;
-        internal MyKeys CycleKey;
-        internal MyKeys PrevKey;
+        internal MyKeys CycleNextKey;
+        internal MyKeys CyclePrevKey;
 
         internal MyMouseButtonsEnum MouseButtonMenu;
 
@@ -77,8 +77,8 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
             WheelForward = false;
             WheelBackward = false;
             AimRay = new LineD();
-            CycleKeyPressed = false;
-            PrevKeyPressed = false;
+            CycleNextKeyPressed = false;
+            CyclePrevKeyPressed = false;
 
             if (!s.InGridAiBlock) s.UpdateLocalAiAndCockpit();
 
@@ -266,19 +266,19 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
             else if (s.UiInput.CurrentWheel != s.UiInput.PreviousWheel)
                 WheelBackward = true;
 
-            if (MyAPIGateway.Input.IsKeyPress(CycleKey) && CycleKeyReleased)
+            if (MyAPIGateway.Input.IsKeyPress(CycleNextKey) && CycleNextKeyReleased)
             {
-                CycleKeyPressed = true;
-                CycleKeyReleased = false;
+                CycleNextKeyPressed = true;
+                CycleNextKeyReleased = false;
             }
-            if (MyAPIGateway.Input.IsNewKeyReleased(CycleKey)) CycleKeyReleased = true;
+            if (MyAPIGateway.Input.IsNewKeyReleased(CycleNextKey)) CycleNextKeyReleased = true;
 
-            if (MyAPIGateway.Input.IsKeyPress(PrevKey) && PrevKeyReleased)
+            if (MyAPIGateway.Input.IsKeyPress(CyclePrevKey) && CyclePrevKeyReleased)
             {
-                PrevKeyPressed = true;
-                PrevKeyReleased = false;
+                CyclePrevKeyPressed = true;
+                CyclePrevKeyReleased = false;
             }
-            if (MyAPIGateway.Input.IsNewKeyReleased(PrevKey)) PrevKeyReleased = true;
+            if (MyAPIGateway.Input.IsNewKeyReleased(CyclePrevKey)) CyclePrevKeyReleased = true;
 
             if (!ActionKeyPressed && BlackListActive1)
                 BlackList1(false);

--- a/Data/Scripts/CoreSystems/Ui/UiInput.cs
+++ b/Data/Scripts/CoreSystems/Ui/UiInput.cs
@@ -26,6 +26,8 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
         internal bool WasInMenu;
         internal bool WheelForward;
         internal bool WheelBackward;
+        internal bool NextKeyPressed;
+        internal bool PrevKeyPressed;
         internal bool ShiftReleased;
         internal bool ShiftPressed;
         internal bool LongShift;
@@ -56,6 +58,8 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
         internal MyKeys ControlKey;
         internal MyKeys ActionKey;
         internal MyKeys InfoKey;
+        internal MyKeys NextKey;
+        internal MyKeys PrevKey;
 
         internal MyMouseButtonsEnum MouseButtonMenu;
 
@@ -121,6 +125,13 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
                 ShiftReleased = MyAPIGateway.Input.IsNewKeyReleased(MyKeys.LeftShift);
                 ShiftPressed = MyAPIGateway.Input.IsKeyPress(MyKeys.LeftShift);
                 ControlKeyReleased = MyAPIGateway.Input.IsNewKeyReleased(ControlKey);
+                if (NextKeyPressed || PrevKeyPressed)
+                {
+                    NextKeyPressed = false;
+                    PrevKeyPressed = false;
+                }
+                NextKeyPressed = MyAPIGateway.Input.IsKeyPress(NextKey);
+                PrevKeyPressed = MyAPIGateway.Input.IsKeyPress(PrevKey);
 
                 if (ShiftPressed)
                 {
@@ -239,6 +250,8 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
                 ActionKeyReleased = false;
                 InfoKeyPressed = false;
                 InfoKeyReleased = false;
+                NextKeyPressed = false;
+                PrevKeyPressed = false;
             }
 
             if (_session.MpActive && !s.InGridAiBlock)

--- a/Data/Scripts/CoreSystems/Ui/UiInput.cs
+++ b/Data/Scripts/CoreSystems/Ui/UiInput.cs
@@ -26,8 +26,8 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
         internal bool WasInMenu;
         internal bool WheelForward;
         internal bool WheelBackward;
-        internal bool NextKeyPressed;
-        internal bool PrevKeyPressed;
+        internal bool CycleKeyPressed;
+        internal bool CycleKeyReleased;
         internal bool ShiftReleased;
         internal bool ShiftPressed;
         internal bool LongShift;
@@ -58,8 +58,7 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
         internal MyKeys ControlKey;
         internal MyKeys ActionKey;
         internal MyKeys InfoKey;
-        internal MyKeys NextKey;
-        internal MyKeys PrevKey;
+        internal MyKeys CycleKey;
 
         internal MyMouseButtonsEnum MouseButtonMenu;
 
@@ -75,6 +74,7 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
             WheelForward = false;
             WheelBackward = false;
             AimRay = new LineD();
+            CycleKeyPressed = false;
 
             if (!s.InGridAiBlock) s.UpdateLocalAiAndCockpit();
 
@@ -125,13 +125,6 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
                 ShiftReleased = MyAPIGateway.Input.IsNewKeyReleased(MyKeys.LeftShift);
                 ShiftPressed = MyAPIGateway.Input.IsKeyPress(MyKeys.LeftShift);
                 ControlKeyReleased = MyAPIGateway.Input.IsNewKeyReleased(ControlKey);
-                if (NextKeyPressed || PrevKeyPressed)
-                {
-                    NextKeyPressed = false;
-                    PrevKeyPressed = false;
-                }
-                NextKeyPressed = MyAPIGateway.Input.IsKeyPress(NextKey);
-                PrevKeyPressed = MyAPIGateway.Input.IsKeyPress(PrevKey);
 
                 if (ShiftPressed)
                 {
@@ -250,8 +243,6 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
                 ActionKeyReleased = false;
                 InfoKeyPressed = false;
                 InfoKeyReleased = false;
-                NextKeyPressed = false;
-                PrevKeyPressed = false;
             }
 
             if (_session.MpActive && !s.InGridAiBlock)
@@ -270,6 +261,16 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
                 WheelForward = true;
             else if (s.UiInput.CurrentWheel != s.UiInput.PreviousWheel)
                 WheelBackward = true;
+
+            if (MyAPIGateway.Input.IsKeyPress(CycleKey) && CycleKeyReleased)
+            {
+                CycleKeyPressed = true;
+                CycleKeyReleased = false;
+            }
+            if (MyAPIGateway.Input.IsNewKeyReleased(CycleKey))
+            {
+                CycleKeyReleased = true;
+            }
 
             if (!ActionKeyPressed && BlackListActive1)
                 BlackList1(false);

--- a/Data/Scripts/CoreSystems/Ui/UiInput.cs
+++ b/Data/Scripts/CoreSystems/Ui/UiInput.cs
@@ -28,6 +28,8 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
         internal bool WheelBackward;
         internal bool CycleKeyPressed;
         internal bool CycleKeyReleased;
+        internal bool PrevKeyPressed;
+        internal bool PrevKeyReleased;
         internal bool ShiftReleased;
         internal bool ShiftPressed;
         internal bool LongShift;
@@ -59,6 +61,7 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
         internal MyKeys ActionKey;
         internal MyKeys InfoKey;
         internal MyKeys CycleKey;
+        internal MyKeys PrevKey;
 
         internal MyMouseButtonsEnum MouseButtonMenu;
 
@@ -75,6 +78,7 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
             WheelBackward = false;
             AimRay = new LineD();
             CycleKeyPressed = false;
+            PrevKeyPressed = false;
 
             if (!s.InGridAiBlock) s.UpdateLocalAiAndCockpit();
 
@@ -268,6 +272,13 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui
                 CycleKeyReleased = false;
             }
             if (MyAPIGateway.Input.IsNewKeyReleased(CycleKey)) CycleKeyReleased = true;
+
+            if (MyAPIGateway.Input.IsKeyPress(PrevKey) && PrevKeyReleased)
+            {
+                PrevKeyPressed = true;
+                PrevKeyReleased = false;
+            }
+            if (MyAPIGateway.Input.IsNewKeyReleased(PrevKey)) PrevKeyReleased = true;
 
             if (!ActionKeyPressed && BlackListActive1)
                 BlackList1(false);


### PR DESCRIPTION
Since DarkStar asked me to write this, I decided to give it a whirl.  I decided to go with added key definitions instead of replacing the mouse wheel functionality.

Since there is a conflict with using a camera to aim/view far away and with mousewheel target selection both using the same keys - camera zoom steals the functionality - so its harder to switch targets in this state.

Two new keys, by default defined as PageUp and PageDn (couldnt figure out the syntax for < > or [ ] which would have been my first choice.

Can be remapped with /wc remap next / prev

Added bool checks alongside other keys, if true are set to false on check, then when checked for state can be set to true.

In the same place it checks for mousewheel status to switch targets, it now also checks for these prev/next key states to also switch targets.

May have missed something, This is untested. I dont know how to set up a test environment to test this myself.