### PR TITLE
Even Moar Nerdy

### DIFF
--- a/Data/Scripts/CoreSystems/Ai/AiConstruct.cs
+++ b/Data/Scripts/CoreSystems/Ai/AiConstruct.cs
@@ -124,6 +124,7 @@ namespace CoreSystems.Support
             internal long TotalPrimaryEffect;
             internal long TotalAOEEffect;
             internal long TotalShieldEffect;
+            internal long TotalProjectileEffect;
             internal double PreviousTotalEffect;
             internal double AddEffect;
             internal double AverageEffect;
@@ -510,7 +511,7 @@ namespace CoreSystems.Support
             {
                 if(TotalEffect>0)
                 {
-                    Log.Stats($"{Data.Ai.ImyGridEntity.DisplayName}, {(long)TotalEffect}, {TotalPrimaryEffect}, {TotalAOEEffect}, {TotalShieldEffect}", "griddmgstats");
+                    Log.Stats($"{Data.Ai.ImyGridEntity.DisplayName}, {(long)TotalEffect}, {TotalPrimaryEffect}, {TotalAOEEffect}, {TotalShieldEffect}, {TotalProjectileEffect}", "griddmgstats");
                 }
                 if (WeaponGroups.Count > 0)
                     CleanWeaponGroups(RootAi.Session);
@@ -520,6 +521,10 @@ namespace CoreSystems.Support
                 BlockCount = 0;
                 AverageEffect = 0;
                 TotalEffect = 0;
+                TotalPrimaryEffect = 0;
+                TotalAOEEffect = 0;
+                TotalShieldEffect = 0;
+                TotalProjectileEffect = 0;
                 PreviousTotalEffect = 0;
                 LastRefreshTick = 0;
                 TargetResetTick = 0;

--- a/Data/Scripts/CoreSystems/EntityComp/EntityFields.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/EntityFields.cs
@@ -62,6 +62,7 @@ namespace CoreSystems.Support
         internal long TotalPrimaryEffect;
         internal long TotalAOEEffect;
         internal long TotalShieldEffect;
+        internal long TotalProjectileEffect;
         internal double PreviousTotalEffect;
         internal double AverageEffect;
         internal double AddEffect;

--- a/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
@@ -443,7 +443,7 @@ namespace CoreSystems.Projectiles
 
             var target = Info.Target;
             CoreComponent comp;
-            var DmgTotal = Info.DamageDoneAOE + Info.DamageDonePri + Info.DamageDoneShld;
+            var DmgTotal = Info.DamageDoneAOE + Info.DamageDonePri + Info.DamageDoneShld + Info.DamageDoneProj;
             if (DmgTotal > 0 && Info.Ai?.Construct.RootAi != null && target.CoreEntity != null && !Info.Ai.MarkedForClose && !target.CoreEntity.MarkedForClose && Info.Ai.CompBase.TryGetValue(target.CoreEntity, out comp))
             {
                 Info.Ai.Construct.RootAi.Construct.TotalEffect += DmgTotal;
@@ -451,9 +451,11 @@ namespace CoreSystems.Projectiles
                 comp.TotalPrimaryEffect += Info.DamageDonePri;
                 comp.TotalAOEEffect += Info.DamageDoneAOE;
                 comp.TotalShieldEffect += Info.DamageDoneShld;
+                comp.TotalProjectileEffect += Info.DamageDoneProj;
                 Info.Ai.Construct.RootAi.Construct.TotalPrimaryEffect += Info.DamageDonePri;
                 Info.Ai.Construct.RootAi.Construct.TotalAOEEffect += Info.DamageDoneAOE;
                 Info.Ai.Construct.RootAi.Construct.TotalShieldEffect += Info.DamageDoneShld;
+                Info.Ai.Construct.RootAi.Construct.TotalProjectileEffect += Info.DamageDoneProj;
             }
 
             if (aConst.ProjectileSync && session.MpActive && session.IsServer)

--- a/Data/Scripts/CoreSystems/Projectiles/ProjectileTypes.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/ProjectileTypes.cs
@@ -60,6 +60,7 @@ namespace CoreSystems.Support
         internal long DamageDonePri;
         internal long DamageDoneAOE;
         internal long DamageDoneShld;
+        internal long DamageDoneProj;
         internal float ShotFade;
         internal float BaseDamagePool;
         internal float BaseHealthPool;
@@ -176,6 +177,7 @@ namespace CoreSystems.Support
             DamageDonePri = 0;
             DamageDoneAOE = 0;
             DamageDoneShld = 0;
+            DamageDoneProj = 0;
             ProjectileDisplacement = 0;
             MaxTrajectory = 0;
             ShotFade = 0;

--- a/Data/Scripts/CoreSystems/Session/SessionCompMgr.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionCompMgr.cs
@@ -248,6 +248,7 @@ namespace CoreSystems
                             storage.Primary += wComp.TotalPrimaryEffect;
                             storage.Shield += wComp.TotalShieldEffect;
                             storage.AOE += wComp.TotalAOEEffect;
+                            storage.Projectile += wComp.TotalProjectileEffect;
                         }
 
                         wComp.GeneralWeaponCleanUp();

--- a/Data/Scripts/CoreSystems/Session/SessionDamageMgr.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionDamageMgr.cs
@@ -877,7 +877,7 @@ namespace CoreSystems
                 var safeObjHp = objHp <= 0 ? 0.0000001f : objHp;
                 var remaining = (scaledDamage / safeObjHp) / damageScale;
                 
-                attacker.DamageDonePri += (long)remaining;
+                attacker.DamageDoneProj += (long)remaining;
                 attacker.BaseDamagePool -= remaining;
 
                 pTarget.Info.BaseHealthPool = 0;
@@ -888,7 +888,7 @@ namespace CoreSystems
             else
             {
                 attacker.BaseDamagePool = 0;
-                attacker.DamageDonePri += (long)scaledDamage;
+                attacker.DamageDoneProj += (long)scaledDamage;
                 pTarget.Info.BaseHealthPool -= scaledDamage;
                 DetonateProjectile(hitEnt, attacker);
             }
@@ -915,14 +915,14 @@ namespace CoreSystems
 
                         if (scaledDamage >= objHp)
                         {
-                            attacker.DamageDonePri += (long)objHp;
+                            attacker.DamageDoneProj += (long)objHp;
                             sTarget.Info.BaseHealthPool = 0;
                             sTarget.State = Projectile.ProjectileState.Detonated;
                         }
                         else
                         {
                             sTarget.Info.BaseHealthPool -= scaledDamage;
-                            attacker.DamageDonePri += (long)scaledDamage;
+                            attacker.DamageDoneProj += (long)scaledDamage;
 
                         }
                     }

--- a/Data/Scripts/CoreSystems/Session/SessionFields.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionFields.cs
@@ -542,8 +542,10 @@ namespace CoreSystems
 
     internal class DamageInfoLog
     {
+        public string TerminalName = "";
         public long Primary = 0;
         public long Shield = 0;
         public long AOE = 0;
+        public long Projectile = 0;
     }
 }

--- a/Data/Scripts/CoreSystems/Session/SessionInit.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionInit.cs
@@ -324,6 +324,7 @@ namespace CoreSystems
                 {
                     try
                     {
+                        if(DmgLog[subTypeIdHash].TerminalName == "") DmgLog[subTypeIdHash].TerminalName=partDef.HardPoint.PartName;
                         modPath = partDef.ModPath;
                         if (partDef.HardPoint.HardWare.Type != Phantom)
                         {

--- a/Data/Scripts/CoreSystems/Session/SessionRun.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionRun.cs
@@ -406,20 +406,18 @@ namespace CoreSystems
 
                 MyVisualScriptLogicProvider.PlayerDisconnected -= PlayerDisconnected;
                 MyVisualScriptLogicProvider.PlayerRespawnRequest -= PlayerConnected;
+                foreach (var pair in DmgLog)
+                {
+                    var x = pair.Value;
+                    var total = x.Primary + x.AOE + x.Shield + x.Projectile;
+                    if (total>0)Log.Stats($"{x.TerminalName}, {total}, {x.Primary}, {x.AOE}, {x.Shield}, {x.Projectile}", "dmgstats");
+                }
                 ApiServer.Unload();
 
                 PurgeAll();
 
                 Log.Line("Logging stopped.");
-                foreach (var pair in DmgLog)
-                {
-                    var x = pair.Value;
-                    var total = x.Primary + x.AOE + x.Shield;
-                    Log.Stats($"{pair.Key.String}, {total}, {x.Primary}, {x.AOE}, {x.Shield}", "dmgstats");
-                }
-
-
-                    Log.Close();
+                Log.Close();
             }
             catch (Exception ex) { Log.Line($"Exception in UnloadData: {ex}", null, true); }
         }

--- a/Data/Scripts/CoreSystems/Support/Log.cs
+++ b/Data/Scripts/CoreSystems/Support/Log.cs
@@ -121,11 +121,11 @@ namespace CoreSystems.Support
                 }
                 else if (name == "dmgstats")
                 {
-                    Stats("WeaponName, TotalDamage, PrimaryDamage, AOEDamage, ShieldDamage", name);
+                    Stats("WeaponName, TotalDamage, PrimaryDamage, AOEDamage, ShieldDamage, ProjectileDamage", name);
                 }
                 else if (name == "griddmgstats")
                 {
-                    Stats("GridName, TotalDamage, PrimaryDamage, AOEDamage, ShieldDamage", name);
+                    Stats("GridName, TotalDamage, PrimaryDamage, AOEDamage, ShieldDamage, ProjectileDamage", name);
                 }
                 else
                 {


### PR DESCRIPTION
-Split out anti-projectile damage from primary damage
-Suppressed log output of weapons that did zero damage
-Weapon damage log now displays terminal name, to match weapon config scrape
-Probably something else